### PR TITLE
eos-data-distribution (0.1.1) UNRELEASED; urgency=medium

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+eos-data-distribution (0.1.1) UNRELEASED; urgency=medium
+
+  * Split edd-avahi-monitor and edd-usb-producer to their own packages
+
+ -- Niv Sardi <xaiki@endlessm.com>  Mon, 13 Mar 2017 11:26:48 -0300
+
 eos-data-distribution (0.1.0) UNRELEASED; urgency=medium
 
   * Initial Debian directory and packaging

--- a/debian/control
+++ b/debian/control
@@ -42,3 +42,29 @@ Description: NDN producers and daemons (Python 2)
  network.
  .
  This package contains the services and library for Python 2.
+
+Package: edd-avahi-monitor
+Architecture: all
+Depends:
+ ${misc:Depends},
+ ${python:Depends},
+ python-eos-data-distribution
+Description: NDN avahi monitor
+ Named Data Networking provides name-based access to data over the
+ network.
+ .
+ This package contains a service that will monitor the avahi network to
+ discover NDN peers
+
+Package: edd-usb-producer
+Architecture: all
+Depends:
+ ${misc:Depends},
+ ${python:Depends},
+ python-eos-data-distribution
+Description: NDN USB producer
+ Named Data Networking provides name-based access to data over the
+ network.
+ .
+ This package contains a service that will monitor USB drives for NDN data
+ spawning a producer when one is plugged into the machine

--- a/debian/edd-avahi-monitor.install
+++ b/debian/edd-avahi-monitor.install
@@ -1,1 +1,2 @@
 debian/edd-avahi-monitor.service lib/systemd/system
+usr/bin/edd-avahi-monitor

--- a/debian/edd-avahi-monitor.install
+++ b/debian/edd-avahi-monitor.install
@@ -1,0 +1,1 @@
+debian/edd-avahi-monitor.service lib/systemd/system

--- a/debian/edd-usb-producer.install
+++ b/debian/edd-usb-producer.install
@@ -1,0 +1,2 @@
+debian/avahi/70-edd-usb-producer.rules usr/lib/udev/rules.d
+debian/edd-usb-producer.service lib/systemd/system

--- a/debian/edd-usb-producer.install
+++ b/debian/edd-usb-producer.install
@@ -1,2 +1,3 @@
 debian/avahi/70-edd-usb-producer.rules usr/lib/udev/rules.d
 debian/edd-usb-producer.service lib/systemd/system
+usr/bin/edd-usb-producer

--- a/debian/python-eos-data-distribution.install
+++ b/debian/python-eos-data-distribution.install
@@ -1,9 +1,6 @@
-debian/avahi/70-edd-usb-producer.rules usr/lib/udev/rules.d
 debian/com.endlessm.EknSubscriptionsDownloader.service usr/share/dbus-1/services
-debian/edd-avahi-monitor.service lib/systemd/system
 debian/edd-ostree-store.service lib/systemd/system
 debian/edd-soma-subscriptions-producer.service lib/systemd/system
-debian/edd-usb-producer.service lib/systemd/system
 debian/eos-data-distribution.conf usr/lib/tmpfiles.d
 debian/soy502-updater.desktop usr/share/applications
 debian/prensa-libre-updater.desktop usr/share/applications

--- a/debian/python-eos-data-distribution.install
+++ b/debian/python-eos-data-distribution.install
@@ -4,3 +4,12 @@ debian/edd-soma-subscriptions-producer.service lib/systemd/system
 debian/eos-data-distribution.conf usr/lib/tmpfiles.d
 debian/soy502-updater.desktop usr/share/applications
 debian/prensa-libre-updater.desktop usr/share/applications
+
+usr/bin/edd-dbus-service
+usr/bin/edd-getchunks
+usr/bin/edd-get-subscription
+usr/bin/edd-ostree-store
+usr/bin/edd-putchunks
+usr/bin/edd-soma-subscriptions-producer
+
+usr/lib/*

--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,10 @@ export PYBUILD_NAME=eos-data-distribution
 
 override_dh_install:
 	dh_install --fail-missing
+	mkdir -p debian/edd-avahi-monitor/usr/bin
+	mv debian/python-eos-data-distribution/usr/bin/edd-avahi-monitor debian/edd-avahi-monitor/usr/bin
+	mkdir -p debian/edd-usb-producer/usr/bin
+	mv debian/python-eos-data-distribution/usr/bin/edd-usb-producer debian/edd-usb-producer/usr/bin
 
 # Build Sphinx documentation
 override_dh_sphinxdoc:

--- a/debian/rules
+++ b/debian/rules
@@ -1,17 +1,13 @@
 #! /usr/bin/make -f
 
 export PYBUILD_DISABLE=test
-export PYBUILD_NAME=eos-data-distribution
+
 #export DH_VERBOSE = 1
 %:
 	dh $@ --with python2,sphinxdoc,systemd --buildsystem=pybuild
 
 override_dh_install:
 	dh_install --fail-missing
-	mkdir -p debian/edd-avahi-monitor/usr/bin
-	mv debian/python-eos-data-distribution/usr/bin/edd-avahi-monitor debian/edd-avahi-monitor/usr/bin
-	mkdir -p debian/edd-usb-producer/usr/bin
-	mv debian/python-eos-data-distribution/usr/bin/edd-usb-producer debian/edd-usb-producer/usr/bin
 
 # Build Sphinx documentation
 override_dh_sphinxdoc:


### PR DESCRIPTION
  * Split edd-avahi-monitor and edd-usb-producer to their own packages

 -- Niv Sardi <xaiki@endlessm.com>  Mon, 13 Mar 2017 11:26:48 -0300

https://phabricator.endlessm.com/T13940

Signed-off-by: Niv Sardi <xaiki@evilgiggle.com>